### PR TITLE
Resolve rpm install conflicts

### DIFF
--- a/sos.spec
+++ b/sos.spec
@@ -56,6 +56,9 @@ support technicians and developers.
 %py3_install '--install-scripts=%{_sbindir}'
 %endif
 
+# cleanup to avoid conflicts with sos already installed
+rm -rf %{buildroot}%{_sysconfdir}/%{sosname}
+
 install -d -m 755 %{buildroot}%{_sysconfdir}/%{sosname}
 install -d -m 700 %{buildroot}%{_sysconfdir}/%{sosname}/cleaner
 install -d -m 755 %{buildroot}%{_sysconfdir}/%{sosname}/presets.d


### PR DESCRIPTION
When installing rpm in rhel there are conflicts on existing files To avoid this conflict spec install step will remove the existing files and replace them with the new version
