### PR TITLE
Revert "Revert "Add mlx5_core plugin""

### DIFF
--- a/sos/report/plugins/mlx5_core.py
+++ b/sos/report/plugins/mlx5_core.py
@@ -1,0 +1,28 @@
+# Copyright (C) 2024 Nvidia Corporation,
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, IndependentPlugin
+
+
+class Mlx5_core(Plugin, IndependentPlugin):
+    """The mlx5_core plugin is aimed at collecting debug information related to
+    Mellenox 5th generation network adapters core driver
+    """
+    short_desc = 'Mellanox 5th generation network adapters (ConnectX series)\
+    core driver'
+    plugin_name = 'mlx5_core'
+    profiles = ('hardware', )
+
+    def setup(self):
+        self.add_copy_spec([
+            '/sys/kernel/debug/mlx5/0000:*/*',
+        ])
+
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Reenable mlx5_core plugin as the mlx5 driver was fixed and it doesn't crash from doca 2.8 version.

This reverts commit 732995a2a0b29f761314997536c972ed4a84c0a8.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ ] Is the subject and message clear and concise?
- [ ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
