### PR TITLE
Set mlx config as the default configuration for tool

### DIFF
--- a/sos-nvidia.conf
+++ b/sos-nvidia.conf
@@ -1,0 +1,39 @@
+[global]
+# Set global options here that are not component specific
+# If you would like one global default value to be specifically overridden for
+# just one component, but not others, you may override that value in the
+# component specific section below
+#verbose = 3
+#verify = yes
+batch = yes
+log-size = 10
+journal_size = 10
+plugin_timeout = 300
+cmd_timeout = 300
+low_priority = True
+
+[report]
+# Options that will apply to any `sos report` run should be listed here.
+# Note that the option names *must* be the long-form name as seen in --help
+# output. Use a comma for list delimitations.
+skip-plugins = ssh, flatpack, login
+
+[collect]
+# Options that will apply to any `sos collect` run should be listed here.
+# Note that the option names *must* be the long-form name as seen in --help
+# output. Use a comma for list delimitations
+#primary = myhost.example.com
+#ssh-key = /home/user/.ssh/mykey
+#password = true
+
+[clean]
+# Options that will apply to any `sos clean|mask` run should be listed here.
+# Note that the option names *must* be the long-form name as seen in --help
+# output. Use a comma for list delimitations
+#domains = mydomain.com
+#no-update = true
+
+[plugin_options]
+# Specify any plugin options and their values here. These options take the form
+# plugin_name.option_name = value
+#rpm.rpmva = off

--- a/sos/__init__.py
+++ b/sos/__init__.py
@@ -123,7 +123,7 @@ class SoS():
                                 help="Do not prompt interactively")
         global_grp.add_argument("--config-file", type=str, action="store",
                                 dest="config_file",
-                                default="/etc/sos/sos.conf",
+                                default="/etc/sos/sos-nvidia.conf",
                                 help="specify alternate configuration file")
         global_grp.add_argument("--debug", action="store_true", dest="debug",
                                 help="enable interactive debugging using the "


### PR DESCRIPTION
instead of running with a specific config file
  sos report --config-file /etc/sos/sos-mlx-cloud-verification.conf

user will be able to run only
  sos report
