### PR TITLE
Add sosreport docker image

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  # Docker images
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore:"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore:"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,70 @@
+name: release
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'image tag prefix'
+        default: 'preview'
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # for creating OIDC tokens for signing.
+      packages: write # for pushing and signing container images.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Prepare
+        id: prep
+        run: |
+          VERSION="${{ github.event.inputs.tag }}-${GITHUB_SHA::8}"
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF/refs\/tags\//}
+          fi
+          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@4574d27a4764455b42196d70a065bc6853246a25 # v3.4.0
+      - name: Setup Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_TOKEN }}
+      - name: Generate images meta
+        id: meta
+        uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 # v5.6.1
+        with:
+          images: |
+            ghcr.io/nvidia/sosreport
+          tags: |
+            type=raw,value=${{ steps.prep.outputs.VERSION }}
+      - name: Publish images
+        id: build-push
+        uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6.13.0
+        with:
+          sbom: true
+          provenance: true
+          push: true
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - uses: sigstore/cosign-installer@c56c2d3e59e4281cc41dea2217323ba5694b171e # v3.8.0
+      - name: Sign images
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          cosign sign --yes ghcr.io/nvidia/sosreport@${{ steps.build-push.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,103 @@
+# syntax=docker/dockerfile:1.4
+
+# Build image to compile all packages
+# The target repository is  https://github.com/NVIDIA/doca-sosreport
+FROM ubuntu:24.04 AS build
+
+ARG PYTHON_VERSION=3.12
+
+RUN apt-get update -qy && apt-get install -qyy \
+    -o APT::Install-Recommends=false \
+    -o APT::Install-Suggests=false \
+    build-essential \
+    ca-certificates \
+    curl \
+    python3-setuptools \
+    python${PYTHON_VERSION}-dev && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+COPY --from=ghcr.io/astral-sh/uv:0.6 /uv /usr/local/bin/uv
+
+ENV UV_LINK_MODE=copy \
+    UV_COMPILE_BYTECODE=1 \
+    UV_PYTHON_DOWNLOADS=never \
+    UV_PYTHON=python3.12
+
+ENV VIRTUAL_ENV=/opt/venv \
+    PATH="/opt/venv/bin:$PATH"
+
+COPY setup.py .
+COPY sos sos
+COPY bin bin
+COPY man man
+COPY tmpfiles tmpfiles
+COPY LICENSE .
+COPY AUTHORS .
+COPY README.md .
+COPY sos.conf .
+COPY sos-mlx-cloud-verification.conf .
+COPY sos-nvidia.conf .
+
+RUN --mount=type=cache,target=/root/.cache \
+    uv venv /opt/venv && uv pip install .
+
+FROM ubuntu:24.04
+
+ARG TARGETARCH
+ARG KUBERNETES_VERSION=1.32
+ARG MFT_VERSION=4.29.0-131
+ARG PYTHON_VERSION=3.12
+
+ENV TAR_OPTIONS="--no-same-owner"
+
+RUN apt-get update && apt-get install -y --allow-downgrades --no-install-recommends \
+    apt-transport-https \
+    ca-certificates \
+    gpg \
+    curl \
+    pciutils \
+    systemd \
+    util-linux \
+    libudev-dev \
+    lshw \
+    lvm2 \
+    mdadm \
+    multipath-tools \
+    iproute2 \
+    inetutils-traceroute \
+    ethtool \
+    bridge-utils \
+    dmidecode
+
+RUN apt-get update -qy && apt-get install -qyy \
+    -o APT::Install-Recommends=false \
+    -o APT::Install-Suggests=false \
+    python${PYTHON_VERSION} \
+    libpython${PYTHON_VERSION} && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,target=/root/.cache \
+    case ${TARGETARCH} in \
+        amd64) curl -fsSL https://www.mellanox.com/downloads/MFT/mft-${MFT_VERSION}-x86_64-deb.tgz | tar -xz -C /tmp && \
+                cd /tmp/mft-${MFT_VERSION}-x86_64-deb && \
+                ./install.sh --without-kernel ;; \
+        arm64) curl -fsSL https://www.mellanox.com/downloads/MFT/mft-${MFT_VERSION}-arm64-deb.tgz | tar -xz -C /tmp && \
+                cd /tmp/mft-${MFT_VERSION}-arm64-deb && \
+                ./install.sh --without-kernel ;; \
+        *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
+    esac
+
+# TODO: If we plan support for additional container runtimes, we need to install the corresponding packages here.
+RUN --mount=type=cache,target=/root/.cache \
+    curl -fsSL https://pkgs.k8s.io/core:/stable:/v${KUBERNETES_VERSION}/deb/Release.key \
+    | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v${KUBERNETES_VERSION}/deb/ /" \
+    | tee /etc/apt/sources.list.d/kubernetes.list && \
+    apt-get update && apt-get install -y cri-tools kubectl
+
+COPY --from=build /opt/venv /opt/venv
+COPY sos-mlx-cloud-verification.conf /etc/sos/sos.conf
+
+COPY --chmod=0755 scripts/report.sh /usr/local/bin/sos-report
+
+ENV PATH="/opt/venv/bin:$PATH"

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,9 +67,10 @@ RUN apt-get update && apt-get install -y --allow-downgrades --no-install-recomme
     inetutils-traceroute \
     ethtool \
     bridge-utils \
-    dmidecode
+    dmidecode && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN apt-get update -qy && apt-get install -qyy \
+RUN apt-get update -y && apt-get install -y \
     -o APT::Install-Recommends=false \
     -o APT::Install-Suggests=false \
     python${PYTHON_VERSION} \
@@ -93,7 +94,8 @@ RUN --mount=type=cache,target=/root/.cache \
     | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg && \
     echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v${KUBERNETES_VERSION}/deb/ /" \
     | tee /etc/apt/sources.list.d/kubernetes.list && \
-    apt-get update && apt-get install -y cri-tools kubectl
+    apt-get update -y && apt-get install -y cri-tools kubectl && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /opt/venv /opt/venv
 COPY sos-mlx-cloud-verification.conf /etc/sos/sos.conf
@@ -101,3 +103,5 @@ COPY sos-mlx-cloud-verification.conf /etc/sos/sos.conf
 COPY --chmod=0755 scripts/report.sh /usr/local/bin/sos-report
 
 ENV PATH="/opt/venv/bin:$PATH"
+
+ENTRYPOINT ["/usr/local/bin/sos-report"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+# Image URL to use all building/pushing image targets
+IMG ?= NVIDIA/doca-sosreport
+TAG ?= latest
+
+# Allows for defining additional Docker buildx arguments,
+# e.g. '--push'.
+BUILD_ARGS ?= --load
+# Architectures to build images for
+BUILD_PLATFORMS ?= linux/amd64,linux/arm64
+
+
+docker-build:  ## Build the Docker image
+	docker buildx build \
+		--platform=$(BUILD_PLATFORMS) \
+		-t $(IMG):$(TAG) \
+		$(BUILD_ARGS) .
+
+docker-push:  ## Push Docker image
+	docker push $(IMG):$(TAG)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets
-IMG ?= NVIDIA/doca-sosreport
+IMG ?= ghcr.io/nvidia/sosreport
 TAG ?= latest
 
 # Allows for defining additional Docker buildx arguments,

--- a/README.md
+++ b/README.md
@@ -166,3 +166,41 @@ Ubuntu (14.04 LTS and above) users install via apt:
  [7]: https://www.sphinx-doc.org/
  [8]: https://www.readthedocs.org/
  [9]: https://github.com/sosreport/sos/wiki
+
+ ### Docker
+
+ It is possible to use the sosreport tool in a Docker container. To build the image,
+ run:
+
+ ```
+ # docker build -t sosreport .
+ ```
+
+ It is also possible to use the pre-built image from GitHub Container Registry:
+
+ ```
+ # docker pull ghcr.io/nvidia/sosreport:${TAG}
+```
+
+To run the container on `linux`, use the following command:
+
+```
+# docker run --rm -it --privileged \
+  -e CASE_ID=123456 \
+  -e DEBUG=true \
+  -v /:/host:ro \
+  -v /run:/run:ro \
+  -v /var/log:/var/log:ro \
+  -v /etc/localtime:/etc/localtime:ro \
+  -v /etc/machine-id:/etc/machine-id:ro \
+  -v /boot:/boot:ro \
+  -v /usr/lib/modules/:/usr/lib/modules/:ro \
+  -v /etc/kubernetes/admin.conf:/etc/kubernetes/admin.conf:ro \
+  --network host \
+  --pid host \
+  --ipc host \
+  ghcr.io/nvidia/sosreport:${TAG} 
+```
+
+**Note**: The `--privileged` flag is required to run sosreport in a container.
+Networking, IPC, and PID namespaces are shared with the host to collect the necessary data.

--- a/scripts/report.sh
+++ b/scripts/report.sh
@@ -24,15 +24,15 @@ set -eo pipefail
 
 OUTPUT_DIR=/host/tmp
 
+declare options
 if [ -n "$CASE_ID" ]; then
-	case_id="--case-id $CASE_ID"
+	options+=("--case-id $CASE_ID")
 fi
 if [ "$DEBUG" == "true" ] ; then
-	verbose="-v"
+	options+=("-v")
 fi
 
-options="$case_id $verbose"
-sos report -s /host -a --all-logs --plugin-timeout 500 --cmd-timeout 120 --batch $options | tee /tmp/log.txt
+sos report -s /host ${options[@]} | tee /tmp/log.txt
 
 tmp_sosreport_file=$(grep 'tar.xz' /tmp/log.txt  | awk '{print $1}')
 sosreport_basename=$(basename $tmp_sosreport_file)

--- a/scripts/report.sh
+++ b/scripts/report.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+#  2025 NVIDIA CORPORATION & AFFILIATES
+#
+#  Licensed under the Apache License, Version 2.0 (the License);
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an AS IS BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# This script will generate a sos report and a dpf report
+
+# Variables:
+# CASE_ID - The case number for the support case (optional)
+# DEBUG - Be more verbose (optional)
+
+set -eo pipefail
+
+OUTPUT_DIR=/host/tmp
+
+if [ -n "$CASE_ID" ]; then
+	case_id="--case-id $CASE_ID"
+fi
+if [ "$DEBUG" == "true" ] ; then
+	verbose="-v"
+fi
+
+options="$case_id $verbose"
+sos report -s /host -a --all-logs --plugin-timeout 500 --cmd-timeout 120 --batch $options | tee /tmp/log.txt
+
+tmp_sosreport_file=$(grep 'tar.xz' /tmp/log.txt  | awk '{print $1}')
+sosreport_basename=$(basename $tmp_sosreport_file)
+export sosreport_file=$OUTPUT_DIR/$sosreport_basename
+
+mv "$tmp_sosreport_file" "$sosreport_file"
+chmod 644 "$sosreport_file"
+
+echo "sos report saved to host: /tmp/$sosreport_basename"


### PR DESCRIPTION
This PR setup a workflow to release sos report to ghcr.

It ships with opiniated binaries such as `kubectl, mft, cri-tools` that are needed for `doca_dpf`. 

The `release.yaml` contains everything to build,push and sign the image. The current target is this org's ghcr registry.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [ ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
