### PR TITLE
fix: mellanox_firmware disable resourcedump

### DIFF
--- a/sos/report/plugins/mellanox_firmware.py
+++ b/sos/report/plugins/mellanox_firmware.py
@@ -115,7 +115,7 @@ class MellanoxFirmware(Plugin, IndependentPlugin):
                 ["mlxlink -d ", ""],
                 # segment is hard coded at the moment, no way to get it
                 # out of the firmware
-                ["resourcedump dump --device ", " --segment 0x400"],
+                # ["resourcedump dump --device ", " --segment 0x400"],
             ]
         for device in devices:
             for command in commands:


### PR DESCRIPTION
resource dump is not ready yet and need to be revereted for this release

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ ] Is the subject and message clear and concise?
- [ ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
