### PR TITLE
[coredump] Fix regex of core dump file

### DIFF
--- a/sos/report/plugins/coredump.py
+++ b/sos/report/plugins/coredump.py
@@ -81,7 +81,10 @@ class Coredump(Plugin, IndependentPlugin):
                 continue
             res = cinfo['output']
             if cores_collected < self.get_option("dumps"):
-                core = re.search(r"(^\s*Storage:(.*)(\(present\)))", res, re.M)
+                core = re.search(r"(^\s*Storage:(.*))", res, re.M)
+                if not core:
+                    self._log_info(f"Missing coredump entry for {pid}")
+                    continue
                 try:
                     core_path = core.groups()[1].strip()
                     # a_c_s does not return any information for a skipped file,
@@ -108,9 +111,6 @@ class Coredump(Plugin, IndependentPlugin):
                     linkpath = linkpath.replace('../', '', 1)
                     self.archive.add_link(linkpath, plugpath)
                     cores_collected += 1
-                except AttributeError:
-                    # no match on the re.search()
-                    pass
                 except Exception as err:
                     self._log_info(
                         f"Could not collect coredump for {pid} : {err}"


### PR DESCRIPTION
Remove incorrect "(present)" string in the regex.
Don't assume any attribute error is regex missing coredump so an error will always be logged.
If regex didn't match a core dump file then log it.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ ] Is the subject and message clear and concise?
- [ ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
