### PR TITLE
doca: Use exec_cmd when running sos_script.sh

### DIFF
--- a/sos/report/plugins/doca.py
+++ b/sos/report/plugins/doca.py
@@ -31,7 +31,7 @@ class Doca(Plugin, IndependentPlugin):
         ])
 
         doca_script = '/opt/mellanox/doca/scripts/sos_script.sh'
-        self.add_cmd_output(doca_script)
+        self.exec_cmd(doca_script)
 
         doca_commands_file = '/var/tmp/sos_commands'
         if os.path.isfile(doca_commands_file):


### PR DESCRIPTION
This prevents adding an empty entry in the output.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ x] Is the subject and message clear and concise?
- [ x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
