### PR TITLE
[nvidia] Capture additional nvidia-smi commands

### DIFF
--- a/sos/report/plugins/nvidia.py
+++ b/sos/report/plugins/nvidia.py
@@ -24,12 +24,14 @@ class Nvidia(Plugin, IndependentPlugin):
         self.add_copy_spec("/etc/cdi/nvidia.yaml")
 
         subcmds = [
+            '',
             '--list-gpus',
             '-q -d PERFORMANCE',
             '-q -d SUPPORTED_CLOCKS',
             '-q -d PAGE_RETIREMENT',
             '-q',
             '-q -d ECC',
+            'topo -m',
             'nvlink -s',
             'nvlink -e'
         ]


### PR DESCRIPTION
Capture 'nvidia-smi' and 'nvidia-smi topo -m' commands/outputs. The former one provides general overview, while the latter one displays topology information in form of the PCIe/NUMA-aware connectivity type matrix to faciliate the NVIDIA GPUDirect and RDMA diagnostics.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
