### PR TITLE
Make output directory configurable

### DIFF
--- a/scripts/report.sh
+++ b/scripts/report.sh
@@ -22,7 +22,7 @@
 
 set -eo pipefail
 
-OUTPUT_DIR=/host/tmp
+: "${OUTPUT_DIR:=/host/tmp}"
 
 declare options
 if [ -n "$CASE_ID" ]; then


### PR DESCRIPTION
In some cases we want the sos report to be exported in a different directory than /tmp.
we made the OUTPUT_DIR variable to be configurable
so consumers can choose to change the sos report output to a path of their choice.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
