### PR TITLE
mlx5_core: Add OFED-only sysfs files and commands

### DIFF
--- a/sos/report/plugins/mlx5_core.py
+++ b/sos/report/plugins/mlx5_core.py
@@ -7,22 +7,65 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-from sos.report.plugins import Plugin, IndependentPlugin
+from sos.report.plugins import Plugin, IndependentPlugin, PluginOpt
 
 
 class Mlx5_core(Plugin, IndependentPlugin):
     """The mlx5_core plugin is aimed at collecting debug information related to
-    Mellenox 5th generation network adapters core driver
+    Mellanox 5th generation network adapters core driver
     """
     short_desc = 'Mellanox 5th generation network adapters (ConnectX series)\
     core driver'
     plugin_name = 'mlx5_core'
     profiles = ('hardware', )
 
+    option_list = [
+        PluginOpt("firmware-dump", default=False,
+                  desc="collect firmware dump data (ethtool -w) for mlx5 devices")
+    ]
+
     def setup(self):
         self.add_copy_spec([
+            # Debug and kernel information
             '/sys/kernel/debug/mlx5/0000:*/*',
+            # Network device settings and statistics
+            '/sys/class/net/*/hp_oob_cnt',
+            '/sys/class/net/*/hp_oob_cnt_mode',
+            '/sys/class/net/*/hp_queues/*/rate',
+            '/sys/class/net/*/rep_config/miss_rl_cfg',
+            '/sys/class/net/*/rep_config/miss_rl_dropped_packets',
+            '/sys/class/net/*/rep_config/miss_rl_dropped_bytes',
+            '/sys/class/net/*/rep_config/miss_rl_stats_clr',
+            '/sys/devices/*/*/*/net/*/settings/force_local_lb_disable',
+            # SR-IOV and VF configurations
+            '/sys/class/net/*/device/sriov/*/meters/*/*/*',
+            '/sys/class/infiniband/*/device/sriov/*/vlan',
+            '/sys/class/infiniband/*/device/sriov/*/config',
+            # InfiniBand
+            '/sys/class/infiniband/*/ttl/*/ttl',
+            '/sys/class/infiniband/*/tc/*/traffic_class',
+            # devlink
+            '/sys/devices/*/*/*/net/*/compat/devlink/*',
         ])
 
+        # Collect RSS hash indirection table information for all ethernet devices
+        self.add_device_cmd([
+            "ethtool -x %(dev)s"
+        ], devices='ethernet')
+
+        # Collect firmware dump information for all ethernet devices
+        # This shows dump flag, version, and length of dump data
+        # NOTE: ethtool -w is deprecated and only shows results for kernels below 6.1
+        self.add_device_cmd([
+            "ethtool -w %(dev)s"
+        ], devices='ethernet')
+
+        # Collect actual firmware dump data if option is enabled
+        if self.get_option("firmware-dump"):
+            self._log_warn("WARNING: collecting firmware dump data may take "
+                           "time and generate large files")
+            self.add_device_cmd([
+                "ethtool -w %(dev)s data %(dev)s_firmware_dump.bin"
+            ], devices='ethernet')
 
 # vim: set et ts=4 sw=4 :

--- a/sos/report/plugins/openvswitch.py
+++ b/sos/report/plugins/openvswitch.py
@@ -126,6 +126,8 @@ class OpenVSwitch(Plugin):
             f"{self.vctl} -t 5 list datapath",
             # Capture OVS mirror list
             f"{self.vctl} -t 5 list mirror",
+            # Capture OVS sflow list
+            f"{self.vctl} -t 5 list sflow",
             # Capture DPDK queue to pmd mapping
             f"{self.actl} dpif-netdev/pmd-rxq-show -secs 5",
             f"{self.actl} dpif-netdev/pmd-rxq-show -secs 30",


### PR DESCRIPTION
Enhance the mlx5_core plugin with OFED-specific
features and improve OpenVSwitch sFlow collection.

mlx5_core plugin enhancements:
- Add ethtool RSS hash collection (ethtool -x) for all ethernet devices
- Add ethtool firmware dump support (ethtool -w) with deprecation notice for kernels >= 6.1
- Add optional firmware dump data collection via --firmware-dump option
- Add sysfs path collection organized by category:
  * Network device settings: hairpin counters, rate limiting, local loopback
  * SR-IOV and VF configurations: meters, VLAN, config
  * InfiniBand settings: TTL and traffic class overrides
  * devlink compatibility paths

OpenVSwitch plugin enhancement:
- Add sFlow configuration collection (ovs-vsctl list sflow)

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ ] Is the subject and message clear and concise?
- [ ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
