### PR TITLE
doca: Fix path for sos_script.sh

### DIFF
--- a/sos/report/plugins/doca.py
+++ b/sos/report/plugins/doca.py
@@ -30,7 +30,7 @@ class Doca(Plugin, IndependentPlugin):
             f'{doca_caps}',
         ])
 
-        doca_script = '/opt/mellanox/doca/scripts/sos_script.sh'
+        doca_script = '/opt/mellanox/doca/tools/sos_script.sh'
         self.exec_cmd(doca_script)
 
         doca_commands_file = '/var/tmp/sos_commands'


### PR DESCRIPTION
The correct path is /opt/mellanox/doca/tools.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ ] Is the subject and message clear and concise?
- [ ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?
