### PR TITLE
fix: incresae plugin timeout

### DIFF
--- a/sos-nvdebug.conf
+++ b/sos-nvdebug.conf
@@ -8,7 +8,7 @@
 batch = yes
 log-size = 10
 journal_size = 10
-plugin_timeout = 1650
+plugin_timeout = 2000
 cmd_timeout = 300
 low_priority = True
 all_logs = True

--- a/sos-nvidia.conf
+++ b/sos-nvidia.conf
@@ -8,7 +8,7 @@
 batch = yes
 log-size = 10
 journal_size = 10
-plugin_timeout = 1650
+plugin_timeout = 2000
 cmd_timeout = 300
 low_priority = True
 all_logs = True


### PR DESCRIPTION
increase plugin timeout to 2000 seconds to support nodes with 9 NICs

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ ] Is the subject and message clear and concise?
- [ ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [ ] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin execution timeout duration from 1650 to 2000 milliseconds across configuration files to allow extended plugin processing time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->