### PR TITLE
`doca_xplane`: add new plugin

### DIFF
--- a/sos/report/plugins/doca_xplane.py
+++ b/sos/report/plugins/doca_xplane.py
@@ -1,0 +1,67 @@
+import json
+from sos.report.plugins import IndependentPlugin, Plugin
+from sos.utilities import is_executable
+
+SERVICE_NAME = "doca-xplane"
+CLIENT_COMMAND = "doca-xplane-client"
+
+
+class DocaXPlane(Plugin, IndependentPlugin):
+    """Collect DOCA XPlane service data and, when available, CLI state."""
+
+    short_desc = "DOCA XPlane service"
+    plugin_name = "doca_xplane"
+    profiles = ("doca",)
+    packages = (SERVICE_NAME, CLIENT_COMMAND)
+    services = (SERVICE_NAME,)
+    containers = (SERVICE_NAME,)
+    commands = (CLIENT_COMMAND,)
+
+    def setup(self):
+        self.add_copy_spec(
+            [
+                "/opt/mellanox/doca/services/xplane",
+                "/var/log/xplane",
+            ]
+        )
+
+        if is_executable(CLIENT_COMMAND, self.sysroot):
+            self._collect_client()
+
+    def _collect_client(self):
+        self.add_cmd_output(
+            [
+                f"{CLIENT_COMMAND} --version",
+                f"{CLIENT_COMMAND} get-planes-summary",
+                f"{CLIENT_COMMAND} get-topology",
+            ]
+        )
+
+        res = self.collect_cmd_output(f"{CLIENT_COMMAND} get-status")
+
+        if res["status"] != 0:
+            self._log_error("Failed to get status")
+            return
+
+        try:
+            status = json.loads(res["output"])
+            num_planes = status["topologySummary"]["planes"]
+        except Exception as e:
+            self._log_error(f"Failed to parse status: {e}")
+            return
+
+        subcommands = (
+            "get-plane-failures-local",
+            "get-plane-failures-remote",
+            "get-plane-traffic-diverted-from",
+            "get-plane-traffic-diverted-to",
+            "get-plane-traffic-summary",
+        )
+
+        self.add_cmd_output(
+            [
+                f"{CLIENT_COMMAND} {sub} --plane_id {i}"
+                for i in range(num_planes)
+                for sub in subcommands
+            ]
+        )


### PR DESCRIPTION
Add plugins for DOCA XPlane.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DOCA XPlane diagnostics collection: gathers service configuration and unit info, runtime logs, client outputs (version and topology), and dynamic per-plane status/details.
  * CLI-based collection runs only when the client is available, parses topology to determine plane count, and halts further per-plane collection on client errors or malformed output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->