### PR TITLE
[logs] reduce journal size by default

### DIFF
--- a/sos-mlx-cloud-verification.conf
+++ b/sos-mlx-cloud-verification.conf
@@ -37,3 +37,6 @@ skip-plugins = ssh, flatpack, login
 # Specify any plugin options and their values here. These options take the form
 # plugin_name.option_name = value
 #rpm.rpmva = off
+# journalctl --since value (systemd.time(7) syntax). Bounds the journal
+# capture to the last 7 days here, set to 'all' for an unbounded capture.
+logs.journal-since = -7days

--- a/sos-nvdebug.conf
+++ b/sos-nvdebug.conf
@@ -7,11 +7,10 @@
 #verify = yes
 batch = yes
 log-size = 10
-journal_size = 10
+journal_size = 50
 plugin_timeout = 2000
 cmd_timeout = 300
 low_priority = True
-all_logs = True
 
 [report]
 # Options that will apply to any `sos report` run should be listed here.
@@ -39,3 +38,6 @@ only-plugins = openvswitch, rdma, hbn, infiniband, doca, networking, mlx5_core
 # Specify any plugin options and their values here. These options take the form
 # plugin_name.option_name = value
 #rpm.rpmva = off
+# journalctl --since value (systemd.time(7) syntax). Bounds the journal
+# capture to the last 7 days here, set to 'all' for an unbounded capture.
+logs.journal-since = -7days

--- a/sos-nvidia.conf
+++ b/sos-nvidia.conf
@@ -7,11 +7,11 @@
 #verify = yes
 batch = yes
 log-size = 10
-journal_size = 10
+# 50 MB per journalctl capture, 7 days of journal text rarely exceeds this
+journal_size = 50
 plugin_timeout = 2000
 cmd_timeout = 300
 low_priority = True
-all_logs = True
 
 [report]
 # Options that will apply to any `sos report` run should be listed here.
@@ -38,3 +38,7 @@ skip-plugins = ssh, flatpack, login
 # Specify any plugin options and their values here. These options take the form
 # plugin_name.option_name = value
 #rpm.rpmva = off
+
+# journalctl --since value (systemd.time(7) syntax). Bounds the journal
+# capture to the last 7 days here, set to 'all' for an unbounded capture.
+logs.journal-since = -7days

--- a/sos/report/plugins/logs.py
+++ b/sos/report/plugins/logs.py
@@ -10,12 +10,30 @@ import glob
 from sos.report.plugins import Plugin, PluginOpt, IndependentPlugin, CosPlugin
 
 
+JOURNAL_SINCE_LONG_DESC = (
+    "Bounds the journalctl text capture by passing the value to "
+    "`journalctl --since`, which accepts any systemd.time(7) "
+    "expression (e.g. '-7days', '-24hours', '2 hours ago', "
+    "'yesterday', '2026-04-19', '2026-04-19 08:00:00'). Use "
+    "'all' (or leave empty) for no bound. Plugin default 'all', "
+    "overridden to '-7days' by the bundled conf files. See "
+    "`man systemd.time` and `man journalctl`."
+)
+
+
 class LogsBase(Plugin):
 
     short_desc = 'System logs'
 
     plugin_name = "logs"
     profiles = ('system', 'hardware', 'storage')
+
+    option_list = [
+        PluginOpt(name="journal-since", default="all", val_type=str,
+                  desc=("journalctl --since value, e.g. '-7days', "
+                        "or 'all' for no bound"),
+                  long_desc=JOURNAL_SINCE_LONG_DESC)
+    ]
 
     def setup(self):
         rsyslog = 'etc/rsyslog.conf'
@@ -56,6 +74,9 @@ class LogsBase(Plugin):
         self.add_cmd_output("journalctl --disk-usage")
         self.add_dir_listing('/var/log', recursive=True)
 
+        since_raw = (self.get_option("journal-since") or "").strip()
+        since_arg = (None if since_raw.lower() in ("", "all") else since_raw)
+
         # collect journal logs if:
         # - there is some data present, either persistent or runtime only
         # - systemd-journald service exists
@@ -64,9 +85,11 @@ class LogsBase(Plugin):
                       for p in ["/var", "/run"])
         if journal and self.is_service("systemd-journald"):
             self.add_journal(tags=['journal_full', 'journal_all'],
-                             priority=100)
-            self.add_journal(boot="this", tags='journal_since_boot')
-            self.add_journal(boot="last", tags='journal_last_boot')
+                             priority=100, since=since_arg)
+            self.add_journal(boot="this", tags='journal_since_boot',
+                             since=since_arg)
+            self.add_journal(boot="last", tags='journal_last_boot',
+                             since=since_arg)
             if self.get_option("all_logs"):
                 self.add_copy_spec([
                     "/var/log/journal/*",
@@ -104,7 +127,7 @@ class IndependentLogs(LogsBase, IndependentPlugin):
 
 
 class CosLogs(LogsBase, CosPlugin):
-    option_list = [
+    option_list = LogsBase.option_list + [
         PluginOpt(name="log-days", default=3,
                   desc="the number of days logs to collect")
     ]

--- a/tests/report_tests/plugin_tests/logs.py
+++ b/tests/report_tests/plugin_tests/logs.py
@@ -20,7 +20,7 @@ class LogsPluginTest(StageOneReportTest):
     :avocado: tags=stageone
     """
 
-    sos_cmd = '-o logs --all-logs'
+    sos_cmd = '-o logs --all-logs -k logs.journal-since=all'
 
     def test_journalctl_collections(self):
         self.assertFileCollected('sos_commands/logs/journalctl_--disk-usage')
@@ -29,6 +29,51 @@ class LogsPluginTest(StageOneReportTest):
 
     def test_journal_runtime_collected(self):
         self.assertFileGlobInArchive('/var/log/journal/*')
+
+
+class JournalSinceFiniteTest(StageOneReportTest):
+    """Ensure a finite `journal-since` value reaches the journalctl
+    invocation and shows up in the captured filename.
+
+    :avocado: tags=stageone
+    """
+
+    sos_cmd = '-o logs -k logs.journal-since=-24hours'
+
+    def test_since_arg_in_journalctl_filename(self):
+        self.assertFileGlobInArchive(
+            'sos_commands/logs/journalctl_--no-pager_*--since_-24hours*'
+        )
+
+
+class JournalSinceAllTest(StageOneReportTest):
+    """Ensure `journal-since=all` disables the time bound, no --since
+    argument should appear in any journalctl capture filename.
+
+    Subclasses re-exercise this assertion against other inputs that
+    should produce the same outcome (default value, empty string, etc.)
+    by overriding sos_cmd, see JournalSinceDefaultTest below.
+
+    :avocado: tags=stageone
+    """
+
+    sos_cmd = '-o logs -k logs.journal-since=all'
+
+    def test_no_plugin_since_in_journalctl_filename(self):
+        self.assertFileGlobNotInArchive(
+            'sos_commands/logs/journalctl_*--since*'
+        )
+
+
+class JournalSinceDefaultTest(JournalSinceAllTest):
+    """Same expectation as JournalSinceAllTest, exercised via the
+    plugin default ('all') instead of an explicit -k flag, locks in
+    the default so a future change to it can't slip through silently.
+
+    :avocado: tags=stageone
+    """
+
+    sos_cmd = '-o logs'
 
 
 class JournalSizeLimitTest(StageTwoReportTest):


### PR DESCRIPTION
Reduce the journal size collection by default to 7 days instead of infinite.
Also added validation that we don't collect (by default) old "active" journal files from older OS installations.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- x ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable time-window for journal log collection; shipped configs default to the last 7 days, with "all" available for unbounded capture.
* **Chores**
  * Increased per-capture journal size in one shipped config and removed a global unbounded log setting in favor of the bounded option.
* **Tests**
  * Updated and added tests validating both bounded (finite) and unbounded ("all") journal collection behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->