### PR TITLE
[mellanox_firmware] PCC collector (opt in)

### DIFF
--- a/sos-nvdebug.conf
+++ b/sos-nvdebug.conf
@@ -8,7 +8,7 @@
 batch = yes
 log-size = 10
 journal_size = 50
-plugin_timeout = 2000
+plugin_timeout = 2160
 cmd_timeout = 300
 low_priority = True
 

--- a/sos-nvidia.conf
+++ b/sos-nvidia.conf
@@ -9,7 +9,7 @@ batch = yes
 log-size = 10
 # 50 MB per journalctl capture, 7 days of journal text rarely exceeds this
 journal_size = 50
-plugin_timeout = 2000
+plugin_timeout = 2160
 cmd_timeout = 300
 low_priority = True
 

--- a/sos/report/mellanox_firmware_suite/collectors/collector_manager.py
+++ b/sos/report/mellanox_firmware_suite/collectors/collector_manager.py
@@ -30,5 +30,7 @@ class CollectorManager(object):
             CableCollector().run(self.plugin, ctx)
 
     def collect_pcc_info(self):
+        if not self.plugin.get_option("pcc", default=False):
+            return
         for ctx in self.device_contexts:
             PccCollector().run(self.plugin, ctx)

--- a/sos/report/mellanox_firmware_suite/collectors/collector_manager.py
+++ b/sos/report/mellanox_firmware_suite/collectors/collector_manager.py
@@ -1,7 +1,7 @@
 from .system_collector import SystemCollector
 from .firmware_collector import FirmwareCollector
 from .cable_collector import CableCollector
-from .ppcc_collector import PPCCCollector
+from .pcc_collector import PccCollector
 
 
 class CollectorManager(object):
@@ -13,7 +13,7 @@ class CollectorManager(object):
         self.collect_system_info()
         self.collect_firmware_info()
         self.collect_cable_info()
-        self.collect_ppcc_info()
+        self.collect_pcc_info()
 
     def collect_system_info(self):
         for ctx in self.device_contexts:
@@ -29,6 +29,6 @@ class CollectorManager(object):
         for ctx in self.device_contexts:
             CableCollector().run(self.plugin, ctx)
 
-    def collect_ppcc_info(self):
+    def collect_pcc_info(self):
         for ctx in self.device_contexts:
-            PPCCCollector().run(self.plugin, ctx)
+            PccCollector().run(self.plugin, ctx)

--- a/sos/report/mellanox_firmware_suite/collectors/collector_manager.py
+++ b/sos/report/mellanox_firmware_suite/collectors/collector_manager.py
@@ -1,6 +1,7 @@
 from .system_collector import SystemCollector
 from .firmware_collector import FirmwareCollector
 from .cable_collector import CableCollector
+from .ppcc_collector import PPCCCollector
 
 
 class CollectorManager(object):
@@ -12,6 +13,7 @@ class CollectorManager(object):
         self.collect_system_info()
         self.collect_firmware_info()
         self.collect_cable_info()
+        self.collect_ppcc_info()
 
     def collect_system_info(self):
         for ctx in self.device_contexts:
@@ -26,3 +28,7 @@ class CollectorManager(object):
     def collect_cable_info(self):
         for ctx in self.device_contexts:
             CableCollector().run(self.plugin, ctx)
+
+    def collect_ppcc_info(self):
+        for ctx in self.device_contexts:
+            PPCCCollector().run(self.plugin, ctx)

--- a/sos/report/mellanox_firmware_suite/collectors/collector_manager.py
+++ b/sos/report/mellanox_firmware_suite/collectors/collector_manager.py
@@ -32,5 +32,6 @@ class CollectorManager(object):
     def collect_pcc_info(self):
         if not self.plugin.get_option("pcc", default=False):
             return
+
         for ctx in self.device_contexts:
             PccCollector().run(self.plugin, ctx)

--- a/sos/report/mellanox_firmware_suite/collectors/pcc_collector.py
+++ b/sos/report/mellanox_firmware_suite/collectors/pcc_collector.py
@@ -9,7 +9,7 @@ from ..tools import (
     get_tool,
 )
 
-# mlxreg/mstreg --op uses string cmd_type values from the PPCC PRM.
+# mlxreg/mstreg --op uses string cmd_type values from the PPCC register.
 PpccCommandOptions = Dict[str, str]
 
 
@@ -25,7 +25,7 @@ class PpccCommand(str, Enum):
     ALGO_INFO_ARRAY = "0x10"
 
 
-class PPCCCollector(Collector):
+class PccCollector(Collector):
     _BASE_REGISTER_INDEXES = "local_port=1,pnat=0,lp_msb=0"
     _ALGO_SLOT_TEXT_INDEX_COUNT = 16
     _COMMAND_OUTPUT_LOG_MAX_CHARS = 4000
@@ -46,7 +46,7 @@ class PPCCCollector(Collector):
     @staticmethod
     def _register_indexes_for_algo_slot(algo_slot_index: int) -> str:
         return (
-            f"{PPCCCollector._BASE_REGISTER_INDEXES},"
+            f"{PccCollector._BASE_REGISTER_INDEXES},"
             f"algo_slot={algo_slot_index}"
         )
 
@@ -312,7 +312,7 @@ class PPCCCollector(Collector):
 
     def _collect_ppcc_data(self, plugin, tool, tool_name: str, ctx) -> None:
         collection_file_prefix = f"{tool_name}_{ctx.bdf}_"
-        output_subdir = f"{tool_name}_pcc"
+        output_subdir = f"pcc_info"
         device_label = ctx.device
 
         return_code, output = self._ppcc_get(

--- a/sos/report/mellanox_firmware_suite/collectors/pcc_collector.py
+++ b/sos/report/mellanox_firmware_suite/collectors/pcc_collector.py
@@ -152,7 +152,7 @@ class PccCollector(Collector):
         algo_slot_index: int,
         register_indexes: str,
     ) -> None:
-        device_label = ctx.device
+        device_label = ctx.pci
 
         return_code, output = self._ppcc_get(
             plugin,
@@ -210,7 +210,7 @@ class PccCollector(Collector):
         algo_slot_index: int,
         register_indexes: str,
     ) -> None:
-        device_label = ctx.device
+        device_label = ctx.pci
 
         return_code, output = self._ppcc_get(
             plugin,
@@ -288,7 +288,7 @@ class PccCollector(Collector):
         register_indexes = self._register_indexes_for_algo_slot(
             algo_slot_index
         )
-        device_label = ctx.device
+        device_label = ctx.pci
 
         if algo_slot_index in self._ALGO_SLOTS_COLLECT_STATUS_CMD_ONLY:
             self._ppcc_get(
@@ -352,7 +352,7 @@ class PccCollector(Collector):
     def _collect_ppcc_data(self, plugin, tool, tool_name: str, ctx) -> None:
         collection_file_prefix = f"{tool_name}_{ctx.bdf}_"
         output_subdir = f"pcc_info"
-        device_label = ctx.device
+        device_label = ctx.pci
 
         return_code, output = self._ppcc_get(
             plugin,

--- a/sos/report/mellanox_firmware_suite/collectors/pcc_collector.py
+++ b/sos/report/mellanox_firmware_suite/collectors/pcc_collector.py
@@ -14,6 +14,7 @@ PpccCommandOptions = Dict[str, str]
 
 
 class PpccCommand(str, Enum):
+    GET_ALGO_INFO = "0x0"
     GET_ALGO_STATUS = "0x3"
     GET_NUM_PARAMS = "0x4"
     GET_PARAM_INFO = "0x5"
@@ -28,6 +29,7 @@ class PpccCommand(str, Enum):
 class PccCollector(Collector):
     _BASE_REGISTER_INDEXES = "local_port=1,pnat=0,lp_msb=0"
     _ALGO_SLOT_TEXT_INDEX_COUNT = 16
+    _ALGO_SLOTS_COLLECT_STATUS_CMD_ONLY = frozenset({15})
     _COMMAND_OUTPUT_LOG_MAX_CHARS = 4000
 
     _TEXT_TABLE_LINE_PATTERN = re.compile(
@@ -36,6 +38,10 @@ class PccCollector(Collector):
     )
     _VALUE_FIELD_PATTERN = re.compile(
         r"^\s*value\s*\|\s*0x([0-9a-fA-F]+)",
+        re.MULTILINE | re.IGNORECASE,
+    )
+    _COUNTER_EN_FIELD_PATTERN = re.compile(
+        r"^\s*counter_en\s*\|\s*0x([0-9a-fA-F]+)",
         re.MULTILINE | re.IGNORECASE,
     )
 
@@ -86,6 +92,15 @@ class PccCollector(Collector):
         if not match:
             return None
         return int(match.group(1), 16)
+
+    @classmethod
+    def _counter_en_enabled(cls, mlxreg_output: str) -> Optional[bool]:
+        """LSB of counter_en from algo status dump; None if field missing."""
+        match = cls._COUNTER_EN_FIELD_PATTERN.search(mlxreg_output)
+        if not match:
+            return None
+        v = int(match.group(1), 16)
+        return (v & 1) != 0
 
     @classmethod
     def _clip_command_output(cls, text: str) -> str:
@@ -160,7 +175,7 @@ class PccCollector(Collector):
         )
         for counter_index in range(counter_count):
             counter_indexes = (
-                f"{register_indexes},algo_counter_index={counter_index}"
+                f"{register_indexes},algo_param_index={counter_index}"
             )
             self._ppcc_get(
                 plugin,
@@ -275,6 +290,28 @@ class PccCollector(Collector):
         )
         device_label = ctx.device
 
+        if algo_slot_index in self._ALGO_SLOTS_COLLECT_STATUS_CMD_ONLY:
+            self._ppcc_get(
+                plugin,
+                device_label,
+                tool,
+                collection_file_prefix,
+                output_subdir,
+                self._op_for_cmd_type(PpccCommand.GET_ALGO_STATUS),
+                register_indexes,
+            )
+            return
+
+        self._ppcc_get(
+            plugin,
+            device_label,
+            tool,
+            collection_file_prefix,
+            output_subdir,
+            self._op_for_cmd_type(PpccCommand.GET_ALGO_INFO),
+            register_indexes,
+        )
+
         return_code, output = self._ppcc_get(
             plugin,
             device_label,
@@ -291,15 +328,17 @@ class PccCollector(Collector):
         if algo_status is not None and algo_status != 1:
             return
 
-        self._collect_counters_for_algo_slot(
-            plugin,
-            tool,
-            collection_file_prefix,
-            output_subdir,
-            ctx,
-            algo_slot_index,
-            register_indexes,
-        )
+        counter_en_on = self._counter_en_enabled(output)
+        if counter_en_on is not False:
+            self._collect_counters_for_algo_slot(
+                plugin,
+                tool,
+                collection_file_prefix,
+                output_subdir,
+                ctx,
+                algo_slot_index,
+                register_indexes,
+            )
         self._collect_params_for_algo_slot(
             plugin,
             tool,
@@ -327,7 +366,10 @@ class PccCollector(Collector):
         if return_code != 0:
             return
 
-        present_algo_slots = self._get_algo_slot_indices(output)
+        present_algo_slots = sorted(
+            frozenset(self._get_algo_slot_indices(output))
+            | self._ALGO_SLOTS_COLLECT_STATUS_CMD_ONLY,
+        )
         if not present_algo_slots:
             return
 

--- a/sos/report/mellanox_firmware_suite/collectors/pcc_collector.py
+++ b/sos/report/mellanox_firmware_suite/collectors/pcc_collector.py
@@ -149,7 +149,6 @@ class PccCollector(Collector):
         collection_file_prefix: str,
         output_subdir: str,
         ctx,
-        algo_slot_index: int,
         register_indexes: str,
     ) -> None:
         device_label = ctx.pci
@@ -207,7 +206,6 @@ class PccCollector(Collector):
         collection_file_prefix: str,
         output_subdir: str,
         ctx,
-        algo_slot_index: int,
         register_indexes: str,
     ) -> None:
         device_label = ctx.pci
@@ -329,29 +327,28 @@ class PccCollector(Collector):
             return
 
         counter_en_on = self._counter_en_enabled(output)
-        if counter_en_on is not False:
+        if counter_en_on:
             self._collect_counters_for_algo_slot(
                 plugin,
                 tool,
                 collection_file_prefix,
                 output_subdir,
                 ctx,
-                algo_slot_index,
                 register_indexes,
             )
         self._collect_params_for_algo_slot(
+   
             plugin,
             tool,
             collection_file_prefix,
             output_subdir,
             ctx,
-            algo_slot_index,
             register_indexes,
         )
 
     def _collect_ppcc_data(self, plugin, tool, tool_name: str, ctx) -> None:
         collection_file_prefix = f"{tool_name}_{ctx.bdf}_"
-        output_subdir = f"pcc_info"
+        output_subdir = "pcc_info"
         device_label = ctx.pci
 
         return_code, output = self._ppcc_get(
@@ -370,8 +367,6 @@ class PccCollector(Collector):
             frozenset(self._get_algo_slot_indices(output))
             | self._ALGO_SLOTS_COLLECT_STATUS_CMD_ONLY,
         )
-        if not present_algo_slots:
-            return
 
         for algo_slot_index in present_algo_slots:
             self._collect_single_algo_slot(

--- a/sos/report/mellanox_firmware_suite/collectors/pcc_collector.py
+++ b/sos/report/mellanox_firmware_suite/collectors/pcc_collector.py
@@ -66,6 +66,7 @@ class PccCollector(Collector):
             f"{key}_{value}" for key, value in command_options.items()
         )
         index_part = register_indexes.replace("=", "_").replace(",", "_")
+
         return (
             f"{collection_file_prefix}--reg_name_PPCC_--get_"
             f"--op_{op_part}_--indexes_{index_part}"
@@ -75,11 +76,15 @@ class PccCollector(Collector):
     def _get_algo_slot_indices(cls, mlxreg_output: str) -> List[int]:
         slot_count = cls._ALGO_SLOT_TEXT_INDEX_COUNT
         values_per_slot = [0] * slot_count
+
         for match in cls._TEXT_TABLE_LINE_PATTERN.finditer(mlxreg_output):
             text_index = int(match.group(1))
+
             if text_index >= slot_count:
                 continue
+
             values_per_slot[text_index] = int(match.group(2), 16)
+
         return [
             text_index
             for text_index, value in enumerate(values_per_slot)
@@ -89,27 +94,36 @@ class PccCollector(Collector):
     @classmethod
     def _extract_value_field(cls, mlxreg_output: str) -> Optional[int]:
         match = cls._VALUE_FIELD_PATTERN.search(mlxreg_output)
+
         if not match:
             return None
+
         return int(match.group(1), 16)
 
     @classmethod
     def _counter_en_enabled(cls, mlxreg_output: str) -> Optional[bool]:
         """LSB of counter_en from algo status dump; None if field missing."""
         match = cls._COUNTER_EN_FIELD_PATTERN.search(mlxreg_output)
+
         if not match:
             return None
+
         v = int(match.group(1), 16)
+
         return (v & 1) != 0
 
     @classmethod
     def _clip_command_output(cls, text: str) -> str:
         raw = (text or "").strip()
+
         if not raw:
             return "(empty)"
+
         limit = cls._COMMAND_OUTPUT_LOG_MAX_CHARS
+
         if len(raw) <= limit:
             return raw
+
         return raw[:limit]
 
     def _ppcc_get(
@@ -122,24 +136,29 @@ class PccCollector(Collector):
         command_options: PpccCommandOptions,
         register_indexes: str,
     ) -> Tuple[int, str]:
+        filename = self._make_filename_for_ppcc_get(
+            collection_file_prefix,
+            command_options,
+            register_indexes,
+        )
+
         return_code, output = tool.ppcc_get(
             command_options,
             register_indexes,
-            filename=self._make_filename_for_ppcc_get(
-                collection_file_prefix,
-                command_options,
-                register_indexes,
-            ),
+            filename=filename,
             subdir=output_subdir,
         )
+
         if return_code != 0:
             op = command_options.get("cmd_type", "?")
+            clipped_output = self._clip_command_output(output)
             plugin._log_info(
                 "PPCC command failed "
                 f"device={device_label} cmd_type={op} "
                 f"indexes={register_indexes!r} rc={return_code} "
-                f"output:\n{self._clip_command_output(output)}"
+                f"output:\n{clipped_output}"
             )
+
         return return_code, output
 
     def _collect_counters_for_algo_slot(
@@ -152,6 +171,9 @@ class PccCollector(Collector):
         register_indexes: str,
     ) -> None:
         device_label = ctx.pci
+        get_num_counters_op = self._op_for_cmd_type(
+            PpccCommand.GET_NUM_COUNTERS
+        )
 
         return_code, output = self._ppcc_get(
             plugin,
@@ -159,19 +181,22 @@ class PccCollector(Collector):
             tool,
             collection_file_prefix,
             output_subdir,
-            self._op_for_cmd_type(PpccCommand.GET_NUM_COUNTERS),
+            get_num_counters_op,
             register_indexes,
         )
+
         if return_code != 0:
             return
 
         counter_count = self._extract_value_field(output)
+
         if counter_count is None:
             return
 
         counter_info_op = self._op_for_cmd_type(
             PpccCommand.GET_COUNTER_INFO
         )
+
         for counter_index in range(counter_count):
             counter_indexes = (
                 f"{register_indexes},algo_param_index={counter_index}"
@@ -189,13 +214,17 @@ class PccCollector(Collector):
         if counter_count == 0:
             return
 
+        bulk_get_counters_op = self._op_for_cmd_type(
+            PpccCommand.BULK_GET_COUNTERS
+        )
+
         self._ppcc_get(
             plugin,
             device_label,
             tool,
             collection_file_prefix,
             output_subdir,
-            self._op_for_cmd_type(PpccCommand.BULK_GET_COUNTERS),
+            bulk_get_counters_op,
             register_indexes,
         )
 
@@ -209,6 +238,9 @@ class PccCollector(Collector):
         register_indexes: str,
     ) -> None:
         device_label = ctx.pci
+        get_num_params_op = self._op_for_cmd_type(
+            PpccCommand.GET_NUM_PARAMS
+        )
 
         return_code, output = self._ppcc_get(
             plugin,
@@ -216,19 +248,22 @@ class PccCollector(Collector):
             tool,
             collection_file_prefix,
             output_subdir,
-            self._op_for_cmd_type(PpccCommand.GET_NUM_PARAMS),
+            get_num_params_op,
             register_indexes,
         )
+
         if return_code != 0:
             return
 
         param_count = self._extract_value_field(output)
+
         if param_count is None:
             return
 
         param_info_op = self._op_for_cmd_type(
             PpccCommand.GET_PARAM_INFO
         )
+
         for param_index in range(param_count):
             param_indexes = (
                 f"{register_indexes},algo_param_index={param_index}"
@@ -246,13 +281,17 @@ class PccCollector(Collector):
         if param_count == 0:
             return
 
+        bulk_get_params_op = self._op_for_cmd_type(
+            PpccCommand.BULK_GET_PARAMS
+        )
+
         return_code, _ = self._ppcc_get(
             plugin,
             device_label,
             tool,
             collection_file_prefix,
             output_subdir,
-            self._op_for_cmd_type(PpccCommand.BULK_GET_PARAMS),
+            bulk_get_params_op,
             register_indexes,
         )
 
@@ -260,6 +299,7 @@ class PccCollector(Collector):
             return
 
         get_param_op = self._op_for_cmd_type(PpccCommand.GET_PARAM)
+
         for param_index in range(param_count):
             param_indexes = (
                 f"{register_indexes},algo_param_index={param_index}"
@@ -287,6 +327,9 @@ class PccCollector(Collector):
             algo_slot_index
         )
         device_label = ctx.pci
+        get_algo_status_op = self._op_for_cmd_type(
+            PpccCommand.GET_ALGO_STATUS
+        )
 
         if algo_slot_index in self._ALGO_SLOTS_COLLECT_STATUS_CMD_ONLY:
             self._ppcc_get(
@@ -295,10 +338,15 @@ class PccCollector(Collector):
                 tool,
                 collection_file_prefix,
                 output_subdir,
-                self._op_for_cmd_type(PpccCommand.GET_ALGO_STATUS),
+                get_algo_status_op,
                 register_indexes,
             )
+
             return
+
+        get_algo_info_op = self._op_for_cmd_type(
+            PpccCommand.GET_ALGO_INFO
+        )
 
         self._ppcc_get(
             plugin,
@@ -306,7 +354,7 @@ class PccCollector(Collector):
             tool,
             collection_file_prefix,
             output_subdir,
-            self._op_for_cmd_type(PpccCommand.GET_ALGO_INFO),
+            get_algo_info_op,
             register_indexes,
         )
 
@@ -316,17 +364,20 @@ class PccCollector(Collector):
             tool,
             collection_file_prefix,
             output_subdir,
-            self._op_for_cmd_type(PpccCommand.GET_ALGO_STATUS),
+            get_algo_status_op,
             register_indexes,
         )
+
         if return_code != 0:
             return
 
         algo_status = self._extract_value_field(output)
+
         if algo_status is not None and algo_status != 1:
             return
 
         counter_en_on = self._counter_en_enabled(output)
+
         if counter_en_on:
             self._collect_counters_for_algo_slot(
                 plugin,
@@ -336,6 +387,7 @@ class PccCollector(Collector):
                 ctx,
                 register_indexes,
             )
+
         self._collect_params_for_algo_slot(
             plugin,
             tool,
@@ -349,6 +401,9 @@ class PccCollector(Collector):
         collection_file_prefix = f"{tool_name}_{ctx.bdf}_"
         output_subdir = "pcc_info"
         device_label = ctx.pci
+        algo_info_array_op = self._op_for_cmd_type(
+            PpccCommand.ALGO_INFO_ARRAY
+        )
 
         return_code, output = self._ppcc_get(
             plugin,
@@ -356,15 +411,17 @@ class PccCollector(Collector):
             tool,
             collection_file_prefix,
             output_subdir,
-            self._op_for_cmd_type(PpccCommand.ALGO_INFO_ARRAY),
+            algo_info_array_op,
             self._BASE_REGISTER_INDEXES,
         )
+
         if return_code != 0:
             return
 
+        algo_slots = self._get_algo_slot_indices(output)
+
         present_algo_slots = sorted(
-            frozenset(self._get_algo_slot_indices(output))
-            | self._ALGO_SLOTS_COLLECT_STATUS_CMD_ONLY,
+            frozenset(algo_slots) | self._ALGO_SLOTS_COLLECT_STATUS_CMD_ONLY,
         )
 
         for algo_slot_index in present_algo_slots:

--- a/sos/report/mellanox_firmware_suite/collectors/pcc_collector.py
+++ b/sos/report/mellanox_firmware_suite/collectors/pcc_collector.py
@@ -337,7 +337,6 @@ class PccCollector(Collector):
                 register_indexes,
             )
         self._collect_params_for_algo_slot(
-   
             plugin,
             tool,
             collection_file_prefix,

--- a/sos/report/mellanox_firmware_suite/collectors/ppcc_collector.py
+++ b/sos/report/mellanox_firmware_suite/collectors/ppcc_collector.py
@@ -1,0 +1,350 @@
+import re
+from enum import Enum
+from typing import Dict, List, Optional, Tuple
+
+from .base_collector import Collector
+from ..tools import (
+    MftTools,
+    MstFlintTools,
+    get_tool,
+)
+
+# mlxreg/mstreg --op uses string cmd_type values from the PPCC PRM.
+PpccCommandOptions = Dict[str, str]
+
+
+class PpccCommand(str, Enum):
+    GET_ALGO_STATUS = "0x3"
+    GET_NUM_PARAMS = "0x4"
+    GET_PARAM_INFO = "0x5"
+    GET_PARAM = "0x6"
+    BULK_GET_PARAMS = "0xA"
+    BULK_GET_COUNTERS = "0xC"
+    GET_NUM_COUNTERS = "0xE"
+    GET_COUNTER_INFO = "0xF"
+    ALGO_INFO_ARRAY = "0x10"
+
+
+class PPCCCollector(Collector):
+    _BASE_REGISTER_INDEXES = "local_port=1,pnat=0,lp_msb=0"
+    _ALGO_SLOT_TEXT_INDEX_COUNT = 16
+    _COMMAND_OUTPUT_LOG_MAX_CHARS = 4000
+
+    _TEXT_TABLE_LINE_PATTERN = re.compile(
+        r"^\s*text\[(\d+)\]\s*\|\s*0x([0-9a-fA-F]+)",
+        re.MULTILINE | re.IGNORECASE,
+    )
+    _VALUE_FIELD_PATTERN = re.compile(
+        r"^\s*value\s*\|\s*0x([0-9a-fA-F]+)",
+        re.MULTILINE | re.IGNORECASE,
+    )
+
+    @staticmethod
+    def _op_for_cmd_type(command: PpccCommand) -> PpccCommandOptions:
+        return {"cmd_type": command.value}
+
+    @staticmethod
+    def _register_indexes_for_algo_slot(algo_slot_index: int) -> str:
+        return (
+            f"{PPCCCollector._BASE_REGISTER_INDEXES},"
+            f"algo_slot={algo_slot_index}"
+        )
+
+    @staticmethod
+    def _make_filename_for_ppcc_get(
+        collection_file_prefix: str,
+        command_options: PpccCommandOptions,
+        register_indexes: str,
+    ) -> str:
+        op_part = "_".join(
+            f"{key}_{value}" for key, value in command_options.items()
+        )
+        index_part = register_indexes.replace("=", "_").replace(",", "_")
+        return (
+            f"{collection_file_prefix}--reg_name_PPCC_--get_"
+            f"--op_{op_part}_--indexes_{index_part}"
+        )
+
+    @classmethod
+    def _get_algo_slot_indices(cls, mlxreg_output: str) -> List[int]:
+        slot_count = cls._ALGO_SLOT_TEXT_INDEX_COUNT
+        values_per_slot = [0] * slot_count
+        for match in cls._TEXT_TABLE_LINE_PATTERN.finditer(mlxreg_output):
+            text_index = int(match.group(1))
+            if text_index >= slot_count:
+                continue
+            values_per_slot[text_index] = int(match.group(2), 16)
+        return [
+            text_index
+            for text_index, value in enumerate(values_per_slot)
+            if value != 0
+        ]
+
+    @classmethod
+    def _extract_value_field(cls, mlxreg_output: str) -> Optional[int]:
+        match = cls._VALUE_FIELD_PATTERN.search(mlxreg_output)
+        if not match:
+            return None
+        return int(match.group(1), 16)
+
+    @classmethod
+    def _clip_command_output(cls, text: str) -> str:
+        raw = (text or "").strip()
+        if not raw:
+            return "(empty)"
+        limit = cls._COMMAND_OUTPUT_LOG_MAX_CHARS
+        if len(raw) <= limit:
+            return raw
+        return raw[:limit]
+
+    def _ppcc_get(
+        self,
+        plugin,
+        device_label: str,
+        tool,
+        collection_file_prefix: str,
+        output_subdir: str,
+        command_options: PpccCommandOptions,
+        register_indexes: str,
+    ) -> Tuple[int, str]:
+        return_code, output = tool.ppcc_get(
+            command_options,
+            register_indexes,
+            filename=self._make_filename_for_ppcc_get(
+                collection_file_prefix,
+                command_options,
+                register_indexes,
+            ),
+            subdir=output_subdir,
+        )
+        if return_code != 0:
+            op = command_options.get("cmd_type", "?")
+            plugin._log_info(
+                "PPCC command failed "
+                f"device={device_label} cmd_type={op} "
+                f"indexes={register_indexes!r} rc={return_code} "
+                f"output:\n{self._clip_command_output(output)}"
+            )
+        return return_code, output
+
+    def _collect_counters_for_algo_slot(
+        self,
+        plugin,
+        tool,
+        collection_file_prefix: str,
+        output_subdir: str,
+        ctx,
+        algo_slot_index: int,
+        register_indexes: str,
+    ) -> None:
+        device_label = ctx.device
+
+        return_code, output = self._ppcc_get(
+            plugin,
+            device_label,
+            tool,
+            collection_file_prefix,
+            output_subdir,
+            self._op_for_cmd_type(PpccCommand.GET_NUM_COUNTERS),
+            register_indexes,
+        )
+        if return_code != 0:
+            return
+
+        counter_count = self._extract_value_field(output)
+        if counter_count is None:
+            return
+
+        counter_info_op = self._op_for_cmd_type(
+            PpccCommand.GET_COUNTER_INFO
+        )
+        for counter_index in range(counter_count):
+            counter_indexes = (
+                f"{register_indexes},algo_counter_index={counter_index}"
+            )
+            self._ppcc_get(
+                plugin,
+                device_label,
+                tool,
+                collection_file_prefix,
+                output_subdir,
+                counter_info_op,
+                counter_indexes,
+            )
+
+        if counter_count == 0:
+            return
+
+        self._ppcc_get(
+            plugin,
+            device_label,
+            tool,
+            collection_file_prefix,
+            output_subdir,
+            self._op_for_cmd_type(PpccCommand.BULK_GET_COUNTERS),
+            register_indexes,
+        )
+
+    def _collect_params_for_algo_slot(
+        self,
+        plugin,
+        tool,
+        collection_file_prefix: str,
+        output_subdir: str,
+        ctx,
+        algo_slot_index: int,
+        register_indexes: str,
+    ) -> None:
+        device_label = ctx.device
+
+        return_code, output = self._ppcc_get(
+            plugin,
+            device_label,
+            tool,
+            collection_file_prefix,
+            output_subdir,
+            self._op_for_cmd_type(PpccCommand.GET_NUM_PARAMS),
+            register_indexes,
+        )
+        if return_code != 0:
+            return
+
+        param_count = self._extract_value_field(output)
+        if param_count is None:
+            return
+
+        param_info_op = self._op_for_cmd_type(
+            PpccCommand.GET_PARAM_INFO
+        )
+        for param_index in range(param_count):
+            param_indexes = (
+                f"{register_indexes},algo_param_index={param_index}"
+            )
+            self._ppcc_get(
+                plugin,
+                device_label,
+                tool,
+                collection_file_prefix,
+                output_subdir,
+                param_info_op,
+                param_indexes,
+            )
+
+        if param_count == 0:
+            return
+
+        return_code, _ = self._ppcc_get(
+            plugin,
+            device_label,
+            tool,
+            collection_file_prefix,
+            output_subdir,
+            self._op_for_cmd_type(PpccCommand.BULK_GET_PARAMS),
+            register_indexes,
+        )
+
+        if return_code == 0:
+            return
+
+        get_param_op = self._op_for_cmd_type(PpccCommand.GET_PARAM)
+        for param_index in range(param_count):
+            param_indexes = (
+                f"{register_indexes},algo_param_index={param_index}"
+            )
+            self._ppcc_get(
+                plugin,
+                device_label,
+                tool,
+                collection_file_prefix,
+                output_subdir,
+                get_param_op,
+                param_indexes,
+            )
+
+    def _collect_single_algo_slot(
+        self,
+        plugin,
+        tool,
+        collection_file_prefix: str,
+        output_subdir: str,
+        ctx,
+        algo_slot_index: int,
+    ) -> None:
+        register_indexes = self._register_indexes_for_algo_slot(
+            algo_slot_index
+        )
+        device_label = ctx.device
+
+        return_code, output = self._ppcc_get(
+            plugin,
+            device_label,
+            tool,
+            collection_file_prefix,
+            output_subdir,
+            self._op_for_cmd_type(PpccCommand.GET_ALGO_STATUS),
+            register_indexes,
+        )
+        if return_code != 0:
+            return
+
+        algo_status = self._extract_value_field(output)
+        if algo_status is not None and algo_status != 1:
+            return
+
+        self._collect_counters_for_algo_slot(
+            plugin,
+            tool,
+            collection_file_prefix,
+            output_subdir,
+            ctx,
+            algo_slot_index,
+            register_indexes,
+        )
+        self._collect_params_for_algo_slot(
+            plugin,
+            tool,
+            collection_file_prefix,
+            output_subdir,
+            ctx,
+            algo_slot_index,
+            register_indexes,
+        )
+
+    def _collect_ppcc_data(self, plugin, tool, tool_name: str, ctx) -> None:
+        collection_file_prefix = f"{tool_name}_{ctx.bdf}_"
+        output_subdir = f"{tool_name}_pcc"
+        device_label = ctx.device
+
+        return_code, output = self._ppcc_get(
+            plugin,
+            device_label,
+            tool,
+            collection_file_prefix,
+            output_subdir,
+            self._op_for_cmd_type(PpccCommand.ALGO_INFO_ARRAY),
+            self._BASE_REGISTER_INDEXES,
+        )
+        if return_code != 0:
+            return
+
+        present_algo_slots = self._get_algo_slot_indices(output)
+        if not present_algo_slots:
+            return
+
+        for algo_slot_index in present_algo_slots:
+            self._collect_single_algo_slot(
+                plugin,
+                tool,
+                collection_file_prefix,
+                output_subdir,
+                ctx,
+                algo_slot_index,
+            )
+
+    def _collect_with_mft(self, plugin, ctx):
+        mlxreg_tool = get_tool(MftTools.MLXREG, plugin, ctx)
+        self._collect_ppcc_data(plugin, mlxreg_tool, "mlxreg", ctx)
+
+    def _collect_with_mstflint(self, plugin, ctx):
+        mstreg_tool = get_tool(MstFlintTools.MSTREG, plugin, ctx)
+        self._collect_ppcc_data(plugin, mstreg_tool, "mstreg", ctx)

--- a/sos/report/mellanox_firmware_suite/tools/MFT/mlxreg.py
+++ b/sos/report/mellanox_firmware_suite/tools/MFT/mlxreg.py
@@ -9,3 +9,12 @@ class MlxregTool(BaseTool):
             "--get",
             filename=filename
         )
+
+    def ppcc_get(self, op, indexes, filename=None, subdir=None):
+        op_str = ",".join(f"{k}={v}" for k, v in op.items())
+        return self.execute_cmd(
+            f'mlxreg -d {self.ctx.device} --reg_name PPCC --get '
+            f'--op "{op_str}" --indexes "{indexes}"',
+            filename=filename,
+            subdir=subdir,
+        )

--- a/sos/report/mellanox_firmware_suite/tools/MFT/mlxreg.py
+++ b/sos/report/mellanox_firmware_suite/tools/MFT/mlxreg.py
@@ -10,10 +10,11 @@ class MlxregTool(BaseTool):
             filename=filename
         )
 
+    @supports_fwctl
     def ppcc_get(self, op, indexes, filename=None, subdir=None):
         op_str = ",".join(f"{k}={v}" for k, v in op.items())
         return self.execute_cmd(
-            f'mlxreg -d {self.ctx.device} --reg_name PPCC --get '
+            f'mlxreg -d {self.ctx.effective_device} --reg_name PPCC --get '
             f'--op "{op_str}" --indexes "{indexes}"',
             filename=filename,
             subdir=subdir,

--- a/sos/report/mellanox_firmware_suite/tools/MSTFlint/mstreg.py
+++ b/sos/report/mellanox_firmware_suite/tools/MSTFlint/mstreg.py
@@ -9,3 +9,12 @@ class MstregTool(BaseTool):
             "--get",
             filename=filename
         )
+
+    def ppcc_get(self, op, indexes, filename=None, subdir=None):
+        op_str = ",".join(f"{k}={v}" for k, v in op.items())
+        return self.execute_cmd(
+            f'mstreg -d {self.ctx.device} --reg_name PPCC --get '
+            f'--op "{op_str}" --indexes "{indexes}"',
+            filename=filename,
+            subdir=subdir,
+        )

--- a/sos/report/mellanox_firmware_suite/tools/MSTFlint/mstreg.py
+++ b/sos/report/mellanox_firmware_suite/tools/MSTFlint/mstreg.py
@@ -10,10 +10,11 @@ class MstregTool(BaseTool):
             filename=filename
         )
 
+    @supports_fwctl
     def ppcc_get(self, op, indexes, filename=None, subdir=None):
         op_str = ",".join(f"{k}={v}" for k, v in op.items())
         return self.execute_cmd(
-            f'mstreg -d {self.ctx.device} --reg_name PPCC --get '
+            f'mstreg -d {self.ctx.effective_device} --reg_name PPCC --get '
             f'--op "{op_str}" --indexes "{indexes}"',
             filename=filename,
             subdir=subdir,

--- a/sos/report/mellanox_firmware_suite/tools/base_tool.py
+++ b/sos/report/mellanox_firmware_suite/tools/base_tool.py
@@ -41,14 +41,15 @@ class BaseTool(object):
         cache=True,
         get_cached=True,
         key=None,
-        filename=None
+        filename=None,
+        subdir=None,
     ):
         cache_key = key or cmd
 
         if get_cached and cache_key in self.ctx.cache:
             return self.ctx.cache[cache_key]
 
-        rc, output = self._run_command(cmd, timeout, filename)
+        rc, output = self._run_command(cmd, timeout, filename, subdir=subdir)
 
         if rc != 0:
             self.plugin._log_info(
@@ -60,7 +61,7 @@ class BaseTool(object):
 
         return (rc, output)
 
-    def _run_command(self, cmd, timeout, filename):
+    def _run_command(self, cmd, timeout, filename, subdir=None):
         if filename is None:
             res = self.plugin.exec_cmd(cmd=cmd, timeout=timeout)
 
@@ -70,6 +71,7 @@ class BaseTool(object):
                 suggest_filename=filename,
                 timeout=timeout,
                 stderr=True,
+                subdir=subdir,
             )
 
         return res.get("status", 1), res.get("output", "")

--- a/sos/report/plugins/mellanox_firmware.py
+++ b/sos/report/plugins/mellanox_firmware.py
@@ -9,7 +9,7 @@
 import re
 import shutil
 
-from sos.report.plugins import Plugin, IndependentPlugin
+from sos.report.plugins import Plugin, IndependentPlugin, PluginOpt
 from sos.report.mellanox_firmware_suite.tools import FirmwareTools
 from sos.report.mellanox_firmware_suite.device_context import DeviceContext
 from sos.report.mellanox_firmware_suite.collectors.collector_manager import (
@@ -39,6 +39,17 @@ class MellanoxFirmware(Plugin, IndependentPlugin):
 
     packages = ("mst", "mstflint")
     profiles = ("hardware", "system")
+
+    option_list = [
+        PluginOpt(
+            "pcc",
+            default=False,
+            desc=(
+                "Collect PPCC (mlxreg/mstreg) register dumps; can be slow on "
+                "large systems"
+            ),
+        ),
+    ]
 
     def __init__(self, commons):
         super().__init__(commons=commons)

--- a/sos/report/plugins/mellanox_firmware.py
+++ b/sos/report/plugins/mellanox_firmware.py
@@ -45,8 +45,8 @@ class MellanoxFirmware(Plugin, IndependentPlugin):
             "pcc",
             default=False,
             desc=(
-                "Collect PPCC (mlxreg/mstreg) register dumps; can be slow on "
-                "large systems"
+                "Collect PCC-related PPCC register dumps via mlxreg/mstreg; "
+                "can be slow on large systems"
             ),
         ),
     ]

--- a/sos/report/plugins/mellanox_firmware.py
+++ b/sos/report/plugins/mellanox_firmware.py
@@ -45,8 +45,7 @@ class MellanoxFirmware(Plugin, IndependentPlugin):
             "pcc",
             default=False,
             desc=(
-                "Collect PCC-related PPCC register dumps via mlxreg/mstreg; "
-                "can be slow on large systems"
+                "Collect PCC-related information"
             ),
         ),
     ]

--- a/sos/report/plugins/mellanox_firmware.py
+++ b/sos/report/plugins/mellanox_firmware.py
@@ -23,7 +23,7 @@ class MellanoxFirmware(Plugin, IndependentPlugin):
     using either MFT (flint) or MSTFlint utilities.
     """
 
-    plugin_timeout = 1650
+    plugin_timeout = 2160
     plugin_name = "mellanox_firmware"
     short_desc = "Nvidia (Mellanox) firmware tools output"
 
@@ -81,13 +81,13 @@ class MellanoxFirmware(Plugin, IndependentPlugin):
     def timeout(self):
         base_timeout = super().timeout
         device_count = len([d for d in self.device_contexts if d.primary])
-        expected_timeout = device_count * 180
+        expected_timeout = device_count * 240
 
         if base_timeout < expected_timeout:
             self._log_warn(
                 f"Plugin timeout {base_timeout}s may be too low for "
                 f"{device_count} device(s). Expected ~{expected_timeout}s "
-                f"(~3 minutes per device)."
+                f"(~4 minutes per device)."
             )
 
         return base_timeout


### PR DESCRIPTION
Add a new PCC collector.
This collection is disabled by default and requires
adding "-k mellanox_firmware.pcc=true" to the command line 
to enable it.

Key changes:
- PCC collection via PPCC register with either mlxreg or mstreg
- BaseTool: added subdir parameter for saving the output under
    a dedicated directory within mellanox_firmware output directory
    to reduce clutter

Signed-off-by: Dan Goldberg <dgoldberg@nvidia.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [x] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added optional Performance Counter Collection (PCC) to gather PPCC firmware register information for enhanced diagnostics.
  * PCC is controlled by a new `pcc` plugin setting and is disabled by default.

* **Improvements**
  * Collected command outputs can now be placed into a specified subdirectory for better organization.
  * Increased plugin timeout to 2160 seconds (including related configuration) and adjusted the per-device timeout expectations used for warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->