### PR TITLE
[doca_weave] add doca weave sos report plugin

### DIFF
--- a/sos/report/plugins/doca_weave.py
+++ b/sos/report/plugins/doca_weave.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import IndependentPlugin, Plugin
+
+
+class DocaWeave(Plugin, IndependentPlugin):
+    """
+    Collect DOCA Weave (east-west VPC) runtime state from a DPU node:
+    vnet/attachment state, the flow-controller underlay config, and host-side
+    DHCP state. Container logs are collected by the container_log plugin.
+
+    This needs to run on the DPU (arm64 BlueField) because vpcctl only exists
+    inside the weave containers on the DPU.
+    """
+
+    short_desc = "DOCA Weave east-west VPC runtime state"
+    plugin_name = "doca_weave"
+    profiles = ("doca",)
+
+    # vpcctl ships inside the weave image at / and is not on the host PATH.
+    VPCCTL = "/vpcctl"
+    GRPC_SOCKET_DIR = "/var/run/dpf/weave/grpc"
+    DHCP_SOCKET = f"{GRPC_SOCKET_DIR}/dhcp.sock"
+    # Bind-mounted host path (chart default), persists when the pod is down.
+    DHCP_HOST_DIR = "/var/run/dpf/weave/dhcp"
+    FLOW_CONTROLLER_CONTAINER = "weave-flow-controller"
+    DHCP_AGENT_CONTAINER = "weave-dhcp-agent"
+    WEAVE_CONTAINERS = (FLOW_CONTROLLER_CONTAINER, DHCP_AGENT_CONTAINER)
+
+    containers = WEAVE_CONTAINERS
+    files = (GRPC_SOCKET_DIR, DHCP_HOST_DIR)
+
+    def setup(self):
+        self._collect_config()
+        self._collect_client()
+
+    def _collect_config(self):
+        # ConfigMap mount with no host equivalent, read it via the container.
+        self.add_cmd_output(
+            "cat /var/lib/dpf/weave/flow-controller/underlay-config.yaml",
+            container=self.FLOW_CONTROLLER_CONTAINER,
+            suggest_filename="underlay-config.yaml",
+            subdir="config",
+        )
+        self.add_copy_spec([
+            f"{self.DHCP_HOST_DIR}/last-applied-state.json",
+            f"{self.DHCP_HOST_DIR}/leases.json",
+            f"{self.DHCP_HOST_DIR}/dnsmasq.conf",
+        ])
+
+    def _collect_client(self):
+        self.add_cmd_output(
+            [f"{self.VPCCTL} list-vnet",
+             f"{self.VPCCTL} list-attachment"],
+            container=self.FLOW_CONTROLLER_CONTAINER,
+            subdir="client",
+        )
+
+        # get-dhcp-config talks to dhcp.sock, owned by the dhcp-agent.
+        if self.path_exists(self.DHCP_SOCKET):
+            self.add_cmd_output(f"{self.VPCCTL} get-dhcp-config",
+                                container=self.DHCP_AGENT_CONTAINER,
+                                subdir="client")
+
+# vim: set et ts=4 sw=4


### PR DESCRIPTION
Add a new weave sos report plugin.
This runs on the DPU itself and it will fetch the following things:

- Vnets and attachments
- flow-control underlay config
- container stdout/stderr

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [x] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [x] Is the subject and message clear and concise?
- [x] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [x] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?
- [x] Are all passwords or private data gathered by this PR [obfuscated](https://github.com/sosreport/sos/wiki/How-to-Write-a-Plugin#how-to-prevent-collecting-passwords)?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a report plugin to collect DOCA Weave runtime state from DPU nodes.
  * Captures flow-controller underlay configuration, DHCP host persistence files, and gRPC socket directory listings.
  * Gathers vpcctl client outputs (vnet and attachment lists) and conditionally fetches DHCP config when the socket is present.
  * Collection runs in two ordered phases (config then client); container log collection is not included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->